### PR TITLE
Add Horizontal Scroller component

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "animated-scroll-to": "^1.2.2",
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
     "react-loadable": "^5.4.0",

--- a/client/src/components/ArrowButton.js
+++ b/client/src/components/ArrowButton.js
@@ -1,0 +1,32 @@
+import React, { Component } from 'react';
+import styled from 'styled-components';
+
+const ArrowIcon = styled.div`
+  width: 1.5em;
+  height: 1.5em;
+  border-left: 1px solid
+    ${props => props.theme.arrowColor ? props.theme.arrowColor : 'black'};
+  border-bottom: 1px solid
+    ${props => props.theme.arrowColor ? props.theme.arrowColor : 'black'};
+  transform: translateX(${Math.sqrt(2)*1.5/4}em) scaleY(1.1) rotate(45deg);
+`
+
+const Button = styled.button`
+  display: inline-block;
+  padding: 1em;
+  background: none;
+  border: none;
+  cursor: pointer;
+  transform: ${props => props.reverse ? '' : 'rotate(180deg)'};
+`
+class ArrowButton extends Component {
+  render() {
+    return (
+      <Button className={this.props.className} onClick={this.props.onClick} reverse={this.props.reverse}>
+        <ArrowIcon />
+      </Button>
+    );
+  }
+}
+
+export default ArrowButton;

--- a/client/src/components/HorizontalScroller.js
+++ b/client/src/components/HorizontalScroller.js
@@ -60,11 +60,17 @@ class HorizontalScroller extends Component {
       atStart: true,
       atEnd: false,
     }
+    this.setState({
+      atEnd: (this.scrollList.scrollWidth -
+        (this.scrollList.scrollLeft + this.scrollList.clientWidth)) === 0
+    });
   }
 
   componentDidMount() {
+    const scrollList = this.scrollList;
+
     this.animateScrollToOptions = {
-      element: this.scrollList,
+      element: scrollList,
       cancelOnUserAction: false,
       horizontal: true,
     }

--- a/client/src/components/HorizontalScroller.js
+++ b/client/src/components/HorizontalScroller.js
@@ -1,0 +1,149 @@
+import React, { Component } from 'react';
+import styled from 'styled-components';
+import animateScrollTo from 'animated-scroll-to'
+import theme from '../style/style-theme';
+import { media } from '../style/style-utils';
+import FullWidthContainer from './FullWidthContainer';
+import ArrowButton from './ArrowButton';
+
+const ScrollerContainer = FullWidthContainer.extend`
+  ${media.mdScreen`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin: 0;
+  `}
+`;
+
+const ScrollList = styled.ul`
+  ${props => getHorizontalScrollerDisplay(props.display)};
+  --item-width: 9em;
+  --item-spacing: 1em;
+
+  overflow-x: scroll;
+  white-space: nowrap;
+  padding: 0 calc((100vw - var(--item-width) - var(--item-spacing))/2);
+
+  ${media.mdScreen`
+    --item-width: calc((100% - var(--item-display)*var(--item-spacing))/
+      var(--item-display));
+
+    display: flex;
+    width: 75%;
+    padding: 0;
+    overflow-x: hidden;
+  `}
+`;
+
+const ScrollItem = styled.li`
+  display: inline-block;
+  min-width: var(--item-width);
+  padding: 1em calc(var(--item-spacing)/2);
+  white-space: initial;
+`;
+
+const ScrollerButton = styled(ArrowButton)`
+  display: none;
+
+  ${media.mdScreen`
+    display: unset;
+    visibility: ${props => props.show ? 'visible' : 'hidden'};
+    opacity: ${props => props.show ? 1 : 0};
+    transition: opacity .25s, visibility .25s;
+  `}
+`
+
+class HorizontalScroller extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      atStart: true,
+      atEnd: false,
+    }
+  }
+
+  componentDidMount() {
+    this.animateScrollToOptions = {
+      element: this.scrollList,
+      cancelOnUserAction: false,
+      horizontal: true,
+    }
+  }
+
+  handlePrevClick = (e) => {
+    const scrollList = this.scrollList;
+    const eventTarget = e.target;
+
+    eventTarget.setAttribute("disabled", "");
+    this.setState({atEnd: false});
+
+    animateScrollTo(scrollList.scrollLeft - scrollList.clientWidth, Object.assign({
+      onComplete: () => {
+        eventTarget.removeAttribute("disabled");
+
+        if (scrollList.scrollLeft === 0) {
+          this.setState({atStart: true});
+        }
+      }
+    }, this.animateScrollToOptions));
+  }
+
+  handleNextClick = (e) => {
+    const scrollList = this.scrollList;
+    const eventTarget = e.target;
+
+    eventTarget.setAttribute("disabled", "");
+    this.setState({atStart: false});
+
+    animateScrollTo(scrollList.scrollLeft + scrollList.clientWidth, Object.assign({
+      onComplete: () => {
+        eventTarget.removeAttribute("disabled");
+
+        if (scrollList.scrollWidth - (scrollList.scrollLeft + scrollList.clientWidth) === 0) {
+          this.setState({atEnd: true});
+        }
+      }
+    }, this.animateScrollToOptions));
+  }
+
+  render() {
+    const children = this.props.children;
+
+    return (
+      <ScrollerContainer>
+        <ScrollerButton show={!this.state.atStart} reverse onClick={this.handlePrevClick} />
+        <ScrollList innerRef={ref => {this.scrollList = ref}} display={this.props.display}>
+          {React.Children.map(children, (child) =>
+            <ScrollItem key={child.props.id}>
+              {child}
+            </ScrollItem>
+          )}
+        </ScrollList>
+        <ScrollerButton show={!this.state.atEnd} onClick={this.handleNextClick} />
+      </ScrollerContainer>
+    );
+  }
+}
+
+const getHorizontalScrollerDisplay = (maxDisplay) => {
+  const maxSiteWidth = parseInt(theme.sizes.maxSiteWidth, 10);
+  const mdScreen = parseInt(theme.breakpoints.mdScreen, 10);
+  const minDisplay = 3;
+  const interval = (maxSiteWidth - mdScreen)/(maxDisplay - minDisplay);
+
+  let styles = '';
+  let display = minDisplay;
+
+  for (let minWidth = mdScreen; minWidth <= maxSiteWidth; minWidth += interval) {
+    styles += `
+      @media screen and (min-width: ${minWidth}em) {
+        --item-display: ${display};
+      }
+    `
+    display++;
+  }
+
+  return styles;
+}
+
+export default HorizontalScroller;

--- a/client/src/components/HorizontalScroller.js
+++ b/client/src/components/HorizontalScroller.js
@@ -126,8 +126,8 @@ class HorizontalScroller extends Component {
 }
 
 const getHorizontalScrollerDisplay = (maxDisplay) => {
-  const maxSiteWidth = parseInt(theme.sizes.maxSiteWidth, 10);
-  const mdScreen = parseInt(theme.breakpoints.mdScreen, 10);
+  const maxSiteWidth = parseInt(theme.sizes.maxSiteWidth, 10)/16;
+  const mdScreen = parseInt(theme.breakpoints.mdScreen, 10)/16;
   const minDisplay = 3;
   const interval = (maxSiteWidth - mdScreen)/(maxDisplay - minDisplay);
 

--- a/client/src/components/MediaCard.js
+++ b/client/src/components/MediaCard.js
@@ -1,0 +1,35 @@
+import React, { Component } from 'react';
+import styled from 'styled-components';
+
+const Card = styled.article`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  border-radius: .3em;
+  box-shadow: 0 .1em .6em rgba(0,0,0,.16);
+  background: #fcfcfc;
+`;
+
+const CardImage = styled.img`
+  width: 100%;
+`;
+
+const CardTextBox = styled.div`
+  flex-grow: 1;
+  padding: 1em;
+`;
+
+class MediaCard extends Component {
+  render() {
+    return (
+      <Card>
+        <CardImage src={this.props.imgSrc} alt={this.props.imgAlt} />
+        <CardTextBox>
+          {this.props.children}
+        </CardTextBox>
+      </Card>
+    );
+  }
+}
+
+export default MediaCard;

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -93,6 +93,10 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
+animated-scroll-to@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/animated-scroll-to/-/animated-scroll-to-1.2.2.tgz#d6688e72f3ecec1a296fc2b36fe29290e7fff694"
+
 ansi-align@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"


### PR DESCRIPTION
The Horizontal Scroller component is to be paired with the Media Card component. Its usage will be as follows:
`<HorizontalScroller display="5">`
`<MediaCard imgSrc="org-logo.jpg" imgAlt="Org Logo">`
`<h2>Org Name</h2>`
`<p>Additional information</p>`
`</MediaCard>`
…
`</HorizontalScroller>`

The `display` attribute on `HorizontalScroller` is used to tell the component how many Media Cards to show on full width. The MediaCard attributes are self-explanatory.

The colors of the arrow buttons in the Horizontal Scroller component can be changed by supplying a theme having an `arrowColor` property using a styled-components `ThemeProvider`.