### PR TITLE
Feature/integrate calendar api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@ __pycache__/
 # misc
 .DS_Store
 
+api/ls_ganap/.env
+
 venv


### PR DESCRIPTION
To test the feature, go to /events/google_api/<int:pk> and you will be redirected to the authorization page. Click accept and you will be redirected to the calendar where you can (hopefully) see the event that was added.

A few concerns:
1. Doesn't take into account for when the user cancels the authorization [RESOLVED]
- How I resolved: I made a try-except statement to catch the error for when the user does not grant permission to the app, which just redirects the user back to /events (temporary only).
<img width="641" alt="screen shot 2018-08-12 at 1 14 05 am" src="https://user-images.githubusercontent.com/35568696/43994288-28c3be64-9dcd-11e8-9e5d-16f62d16eddc.png">

2. When there are multiple accounts logged in in Google, this only redirects you to the primary account (so if you authorized for another account, this won't redirect you to that account's calendar) [RESOLVED]
- How I resolved: I used the authUser parameter and made it the email of the creator. I appended it to the redirect link 
<img width="584" alt="screen shot 2018-08-12 at 1 16 38 am" src="https://user-images.githubusercontent.com/35568696/43994297-6365f9ba-9dcd-11e8-910b-48d5168cdbbe.png">

3. The primary key isn't passed to the other view methods. I can't make it pass it to the authentication views because then I'll have to have all the links with each event pk authenticated in my Google Console which is pretty inefficient.
<img width="275" alt="screen shot 2018-08-09 at 12 42 08 am" src="https://user-images.githubusercontent.com/35568696/43851380-16645e8e-9b6d-11e8-9d34-2a46f749a132.png">

<img width="493" alt="screen shot 2018-08-09 at 12 43 08 am" src="https://user-images.githubusercontent.com/35568696/43851416-35f26dfe-9b6d-11e8-9558-9df221d04149.png">

What I just did was make a global variable that will store the pk in the endpoint and that's what I will use when I redirect back to the create_events view after the user is authenticated for the first time. I'm not sure if this is efficient having a global variable store the event_pk but I'm not sure how else to pass it. [RESOLVED]
- How I resolved: I stored the pk in the session before redirecting to the authorize view.
<img width="411" alt="screen shot 2018-08-12 at 1 17 43 am" src="https://user-images.githubusercontent.com/35568696/43994313-8f8bef7c-9dcd-11e8-96ee-135d37f74ac9.png">

- The oauth2callback view then just retrieves the pk from the session so that the user is redirected back to that specific event's page (/events/google_api/<pk>) which will then lead to adding the event to the user's calendar.
<img width="744" alt="screen shot 2018-08-12 at 1 18 27 am" src="https://user-images.githubusercontent.com/35568696/43994336-d09d1d42-9dcd-11e8-9e06-e326035f7bfe.png">

