### PR TITLE
Fix pagination for clusters, events, hosts, office, org_type, sanggu,…

### DIFF
--- a/api/main_events/views/cluster_view.py
+++ b/api/main_events/views/cluster_view.py
@@ -16,9 +16,21 @@ class ClusterList(APIView):
     serializer_class = ClusterSerializer
 
     def get(self, request, format=None):
-        hosts = Cluster.objects.all()
-        serializer = ClusterSerializer(hosts, many=True)
-        return Response(serializer.data)
+        queryset = Cluster.objects.all()
+        pagination_class = ObjectPageNumberPagination
+        paginator = pagination_class()
+
+        if request.method == 'GET' and 'page' in request.GET:
+
+            page = paginator.paginate_queryset(queryset, request)
+            serializer =  ClusterSerializer(page, many=True)
+        
+            return paginator.get_paginated_response(serializer.data)
+
+        else:
+            serializer =  ClusterSerializer(queryset, many=True)
+            return Response({"results" : serializer.data})
+
 
 class ClusterDetail(generics.RetrieveAPIView):
     """

--- a/api/main_events/views/host_view.py
+++ b/api/main_events/views/host_view.py
@@ -9,19 +9,29 @@ from main_events.pagination import ObjectLimitOffsetPagination, ObjectPageNumber
 from rest_framework import status
 
 
-class HostList(generics.ListAPIView):
+class HostList(APIView):
     """
     get: List all the hosts (LS, GS, HS).
     """
-    queryset = EventHost.objects.all()
     serializer_class = HostSerializer
-    # specifies which pagination settings to follow
-    pagination_class = ObjectPageNumberPagination
 
-    def list_items(self, request):
-        queryset = self.get_queryset()
-        serializer = HostSerializer(queryset, many=True)
-        return Response(serializer.data)
+
+    def get(self, request, format=None):
+        queryset = EventHost.objects.all()
+        pagination_class = ObjectPageNumberPagination
+        paginator = pagination_class()
+
+        if request.method == 'GET' and 'page' in request.GET:
+
+            page = paginator.paginate_queryset(queryset, request)
+            serializer =  HostSerializer(page, many=True)
+        
+            return paginator.get_paginated_response(serializer.data)
+
+        else:
+            serializer = HostSerializer(queryset, many=True)
+            
+            return Response({"results" : serializer.data})
 
 class HostDetail(generics.RetrieveAPIView):
     """

--- a/api/main_events/views/office_view.py
+++ b/api/main_events/views/office_view.py
@@ -9,19 +9,27 @@ from main_events.pagination import ObjectLimitOffsetPagination, ObjectPageNumber
 from rest_framework import status
 
 
-class OfficeList(generics.ListAPIView):
+class OfficeList(APIView):
     """
     get: List all the office hosts.
     """
-    queryset = OfficeHost.objects.all()
     serializer_class = OfficeSerializer
-    # specifies which pagination settings to follow
-    pagination_class = ObjectPageNumberPagination
+    def get(self, request, format=None):
+        queryset = OfficeHost.objects.all()
+        pagination_class = ObjectPageNumberPagination
+        paginator = pagination_class()
 
-    def list_items(self, request):
-        queryset = self.get_queryset()
-        serializer = OfficeSerializer(queryset, many=True)
-        return Response(serializer.data)
+        if request.method == 'GET' and 'page' in request.GET:
+
+            page = paginator.paginate_queryset(queryset, request)
+            serializer =  OfficeSerializer(page, many=True)
+        
+            return paginator.get_paginated_response(serializer.data)
+
+        else:
+            serializer =  OfficeSerializer(queryset, many=True)
+            
+            return Response({"results" : serializer.data})
 
 class OfficeDetail(generics.RetrieveUpdateAPIView):
     """

--- a/api/main_events/views/org_type_view.py
+++ b/api/main_events/views/org_type_view.py
@@ -9,19 +9,26 @@ from main_events.pagination import ObjectLimitOffsetPagination, ObjectPageNumber
 from rest_framework import status
 
 
-class OrgTypeList(generics.ListAPIView):
+class OrgTypeList(APIView):
     """
     get: List all the org types (COA and COP).
     """
-    queryset = OrgType.objects.all()
-    serializer_class = org_type_serializer.OrgTypeSerializer
-    # specifies which pagination settings to follow
-    pagination_class = ObjectPageNumberPagination
+    def get(self, request, format=None):
+        queryset = OrgType.objects.all()
+        pagination_class = ObjectPageNumberPagination
+        paginator = pagination_class()
 
-    def list_items(self, request):
-        queryset = self.get_queryset()
-        serializer = OrgTypeSerializer(queryset, many=True)
-        return Response(serializer.data)
+        if request.method == 'GET' and 'page' in request.GET:
+
+            page = paginator.paginate_queryset(queryset, request)
+            serializer =  org_type_serializer.OrgTypeSerializer(page, many=True)
+        
+            return paginator.get_paginated_response(serializer.data)
+
+        else:
+            serializer =  org_type_serializer.OrgTypeSerializer(queryset, many=True)
+            
+            return Response({"results" : serializer.data})
 
 class OrgTypeDetail(generics.RetrieveAPIView):
     """

--- a/api/main_events/views/org_view.py
+++ b/api/main_events/views/org_view.py
@@ -9,19 +9,27 @@ from main_events.pagination import ObjectLimitOffsetPagination, ObjectPageNumber
 from rest_framework import status
 
 
-class OrgList(generics.ListAPIView):
+class OrgList(APIView):
     """
     get: List all the org hosts.
     """
-    queryset = OrgHost.objects.all()
     serializer_class = OrgSerializer
-    # specifies which pagination settings to follow
-    pagination_class = ObjectPageNumberPagination
+    def get(self, request, format=None):
+        queryset = OrgHost.objects.all()
+        pagination_class = ObjectPageNumberPagination
+        paginator = pagination_class()
 
-    def list_items(self, request):
-        queryset = self.get_queryset()
-        serializer = OrgSerializer(queryset, many=True)
-        return Response(serializer.data)
+        if request.method == 'GET' and 'page' in request.GET:
+
+            page = paginator.paginate_queryset(queryset, request)
+            serializer =  OrgSerializer(page, many=True)
+        
+            return paginator.get_paginated_response(serializer.data)
+
+        else:
+            serializer =  OrgSerializer(queryset, many=True)
+            
+            return Response({"results" : serializer.data})
 
 class OrgDetail(generics.RetrieveUpdateAPIView):
     """

--- a/api/main_events/views/sanggu_view.py
+++ b/api/main_events/views/sanggu_view.py
@@ -9,19 +9,28 @@ from main_events.pagination import ObjectLimitOffsetPagination, ObjectPageNumber
 from rest_framework import status
 
 
-class SangguList(generics.ListAPIView):
+class SangguList(APIView):
     """
     get: List all the sanggu hosts.
     """
-    queryset = SangguHost.objects.all()
-    serializer_class = SangguSerializer
-    # specifies which pagination settings to follow
-    pagination_class = ObjectPageNumberPagination
 
-    def list_items(self, request):
-        queryset = self.get_queryset()
-        serializer = SangguSerializer(queryset, many=True)
-        return Response(serializer.data)
+    serializer_class = SangguSerializer
+    def get(self, request, format=None):
+        queryset = SangguHost.objects.all()
+        pagination_class = ObjectPageNumberPagination
+        paginator = pagination_class()
+
+        if request.method == 'GET' and 'page' in request.GET:
+
+            page = paginator.paginate_queryset(queryset, request)
+            serializer =  SangguSerializer(page, many=True)
+        
+            return paginator.get_paginated_response(serializer.data)
+
+        else:
+            serializer =  SangguSerializer(queryset, many=True)
+            
+            return Response({"results" : serializer.data})
 
 class SangguDetail(generics.RetrieveUpdateAPIView):
     """

--- a/api/main_events/views/tag_view.py
+++ b/api/main_events/views/tag_view.py
@@ -9,19 +9,30 @@ from main_events.pagination import ObjectLimitOffsetPagination, ObjectPageNumber
 from rest_framework import status
 
 
-class TagList(generics.ListAPIView):
+class TagList(APIView):
     """
     get: List all the tags.
     """
-    queryset = Tag.objects.all()
     serializer_class = TagSerializer
     # specifies which pagination settings to follow
-    pagination_class = ObjectPageNumberPagination
 
-    def list_items(self, request):
-        queryset = self.get_queryset()
-        serializer = TagSerializer(queryset, many=True)
-        return Response(serializer.data)
+    def get(self, request, format=None):
+        queryset = Tag.objects.all()
+        pagination_class = ObjectPageNumberPagination
+        paginator = pagination_class()
+
+        if request.method == 'GET' and 'page' in request.GET:
+
+            page = paginator.paginate_queryset(queryset, request)
+            serializer =  TagSerializer(page, many=True)
+        
+            return paginator.get_paginated_response(serializer.data)
+
+        else:
+            serializer =  TagSerializer(queryset, many=True)
+            
+            return Response({"results" : serializer.data})
+
 
 class TagDetail(generics.RetrieveAPIView):
     """

--- a/api/main_events/views/venue_view.py
+++ b/api/main_events/views/venue_view.py
@@ -9,21 +9,30 @@ from main_events.pagination import ObjectLimitOffsetPagination, ObjectPageNumber
 from rest_framework import status
 
 
-class VenueList(generics.ListCreateAPIView):
+class VenueList(APIView):
     """
     get: List all the venues.
     post: Create a new venue.
     """
-    queryset = Venue.objects.all()
     serializer_class = venue_serializer.VenueSerializer
-    # specifies which pagination settings to follow
-    pagination_class = ObjectPageNumberPagination
 
-    def list_items(self, request):
-        queryset = self.get_queryset()
-        serializer = VenueSerializer(queryset, many=True)
-        return Response(serializer.data)
+    def get(self, request, format=None):
+        queryset = Venue.objects.all()
+        pagination_class = ObjectPageNumberPagination
+        paginator = pagination_class()
+
+        if request.method == 'GET' and 'page' in request.GET:
+
+            page = paginator.paginate_queryset(queryset, request)
+            serializer =  venue_serializer.VenueSerializer(page, many=True)
         
+            return paginator.get_paginated_response(serializer.data)
+
+        else:
+            serializer =  venue_serializer.VenueSerializer(queryset, many=True)
+            
+            return Response({"results" : serializer.data})
+    
 class VenueDetail(generics.RetrieveUpdateDestroyAPIView):
     """
     get: 


### PR DESCRIPTION
Modified endpoints to return a non-paginated result by default.

Review instructions:
check the ff endpoints:
Get all: 
/clusters
/events
/offices
/orgs
/org_types
/tags
/venues

Pagination:
/clusters?page=1
/events?page=1
/offices?page=1
/orgs?page=1
/org_types?page=1
/tags?page=1
/venues?page=1

*Check if these endpoints return the data in a "results: []" array