### PR TITLE
Fix error and ordering in the Event Filter endpoints

### DIFF
--- a/api/main_events/helper_methods.py
+++ b/api/main_events/helper_methods.py
@@ -3,7 +3,7 @@ from django.db.models import Min
 # helper method for getting date range
 def get_dates_between(start_date, end_date, queryset, event_logistics):
     if(start_date is not None) and (end_date is not None):
-        queryset = queryset.filter(is_accepted=True).annotate(date=Min('event_logistics__date')).filter(event_logistics__date__range=[start_date, end_date]).order_by('date')
+        queryset = queryset.filter(is_approved=True).annotate(date=Min('event_logistics__date')).filter(event_logistics__date__range=[start_date, end_date]).order_by('date')
     else:
         raise Http404
 

--- a/api/main_events/helper_methods.py
+++ b/api/main_events/helper_methods.py
@@ -3,7 +3,7 @@ from django.db.models import Min
 # helper method for getting date range
 def get_dates_between(start_date, end_date, queryset, event_logistics):
     if(start_date is not None) and (end_date is not None):
-        queryset = queryset.filter(is_approved=True).annotate(date=Min('event_logistics__date')).filter(event_logistics__date__range=[start_date, end_date]).order_by('date')
+        queryset = queryset.filter(is_approved=True).filter(event_logistics__date__range=[start_date, end_date]).annotate(date=Min('event_logistics__date')).order_by('date')
     else:
         raise Http404
 

--- a/api/main_events/views/event_view.py
+++ b/api/main_events/views/event_view.py
@@ -137,10 +137,10 @@ class FilterEventByMonth(generics.ListAPIView):
             get_month = date_list[0]
             get_year = date_list[1]
 
-        queryset = Event.objects.annotate(date=Min('event_logistics__date'))
+        queryset = Event.objects.all()
 
         if date is not None:
-            queryset = queryset.filter(is_approved=True, event_logistics__date__month=get_month, event_logistics__date__year=get_year).order_by('date')
+            queryset = queryset.filter(is_approved=True, event_logistics__date__month=get_month, event_logistics__date__year=get_year).annotate(date=Min('event_logistics__date')).order_by('date')
 
         return queryset
 
@@ -279,7 +279,7 @@ class UnapprovedEventList(generics.ListAPIView):
 
     def get_queryset(self):
         user = self.request.user
-        return Event.objects.annotate(date=Min('event_logistics__date')).filter(Q(is_approved=False) & (Q(sanggu_hosts__user=user) | Q(org_hosts__user=user)))
+        return Event.objects.filter(Q(is_approved=False) & (Q(sanggu_hosts__user=user) | Q(org_hosts__user=user))).annotate(date=Min('event_logistics__date')).order_by('date')
 
 class EventLogisticCreate(APIView):
     """


### PR DESCRIPTION
Check:
1. /events/month
2. /events/on
3. /events/week
4. /events/between